### PR TITLE
Fix Dependency Conflict with Werkzeug 3.0.0 in Flask 2.2.2

### DIFF
--- a/services/webapp/Dockerfile
+++ b/services/webapp/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get -y install build-essential
 #------------------------------
 
 # Install Flask etc.
-RUN pip install flask==2.0.2 requests==2.28.1 uwsgi==2.0.21
+RUN pip install flask==2.0.2 requests==2.28.1 uwsgi==2.0.21 Werkzeug==2.2.2
 
 #------------------------------
 # Install Flask project


### PR DESCRIPTION
### Issue
Encountering an issue due to Werkzeug 3.0.0 being installed despite Flask 2.2.2 specifying "Werkzeug>=2.2.0" in requirements. This leads to compatibility problems.

### Fix
To resolve this issue, explicitly add Werkzeug==2.2.2 to the dependencies.